### PR TITLE
aesh: remove `lookup()` fn (unused since dae3df5f)

### DIFF
--- a/?aesh/aes.sh
+++ b/?aesh/aes.sh
@@ -44,11 +44,6 @@ xor_key() {
 	echo $((${1} ^ ${17}))
 }
 
-# s-box definition
-lookup() {
-	eval echo \${$(($1+2))}
-}
-
 # Galois field multiplications modulo AES polynomial
 mul() {
 	a=$1


### PR DESCRIPTION
The `lookup()` function is unused, with the new SubBytes implementation and may be removed.